### PR TITLE
PACKAGE-INFERRED-FIVEAM-TESTER-SYSTEM, plus some refactoring and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # FIVEAM-ASDF : Integrating System Definitions and FiveAM testing #
 
-FIVEAM-ASDF defines a new system class `FIVEAM-TESTER` that provides functionality for running tests using FiveAM and raising an error if the tests fail, or if an unexpected number of tests run.  This provides a definition for the `ASDF:TEST-OP` operation of the defined system.  It's useful for incorporation into a continuous integration framework, as well.
+FIVEAM-ASDF defines a new system class `FIVEAM-TESTER-SYSTEM` that provides functionality
+for running tests using FiveAM and raising an error if the tests fail, or if an unexpected
+number of tests run. This provides a definition for the `ASDF:TEST-OP` operation of the
+defined system. It's useful for incorporation into a continuous integration framework, as
+well.
 
-How to use
-----------
+New in version 3.0 is the system class `PACKAGE-INFERRED-FIVEAM-TESTER-SYSTEM`, which
+combines the behavior of `FIVEAM-TESTER-SYSTEM` with the package-per-file style of 
+[ASDF's PACKAGE-INFERRED-SYSTEM extension](https://common-lisp.net/project/asdf/asdf/The-package_002dinferred_002dsystem-extension.html)
 
-The "fiveam-asdf" ASDF system adds a new subclass of `ASDF:SYSTEM`.  If you wish to test a system,  `foo`, it is usually best to create a subsystem like this:
+## How to use ##
+
+The "fiveam-asdf" ASDF system adds a new subclass of `ASDF:SYSTEM`.  If you wish to test a
+system, `foo`, it is usually best to create a subsystem like this:
 
     (defsystem foo
       :in-order-to ((test-op (test-op "foo/test")))
@@ -17,29 +25,59 @@ The "fiveam-asdf" ASDF system adds a new subclass of `ASDF:SYSTEM`.  If you wish
       :class fiveam-tester
       ....)
 
-Having the tests in this ancillary subsystem avoids the need for your main system to depend on FiveAM itself, so it (and your test definitions) will only be loaded if you actually want to run the tests.
+Having the tests in this ancillary subsystem avoids the need for your main system to
+depend on FiveAM itself, so it (and your test definitions) will only be loaded if you
+actually want to run the tests.
 
-Now, add files with FiveAM tests in them into the components of `foo/test`, as you wish.  See the FiveAM docs for how to do this.
+Now, add files with FiveAM tests in them into the components of `foo/test`, as you wish.
+See the FiveAM docs for how to do this.
+
+### Listing tests to run ###
+
+List the names of all of your tests in the `:TEST-NAMES` property of your test system's
+defsystem.  Entries in here can either be a symbol designator or a cons whose `CAR` is a
+symbol designator and whose `CDR` is a package designator.
+
+If all of your FiveAM test names are defined in a single package, you can set the
+`:test-package` property of your `FIVEAM-TESTER` system, and any package *un*qualified
+elements of `:test-names` will be searched for in the `:test-package`.
+
+Note that FiveAM offers named test *suites*.  Typically it will be most convenient to make
+a small number of such suites for your system, and name only these suites in `test-names`,
+rather than naming each individual test.
 
 ### Integrating with ASDF's TEST-OP ###
 
-List the names of all of your tests in the `:TEST-NAMES` property of your test system's defsystem.  Entries in here can either be a symbol designator or a cons whose `CAR` is a symbol designator and whose `CDR` is a package designator.
+Doing `(asdf:test-system "foo/test")` will run all the tests in the `fiveam-tester`
+system.  However, as above, it is best to use ASDF's `:in-order-to` to connect `foo` to
+`foo/test` for testing purposes.  Then a user can simply do `(asdf:test-system "foo")`
+without needing to know how the tests are implemented.
 
-If all of your FiveAM test names are defined in a single package, you can set the `:test-package` property of your `FIVEAM-TESTER` system, and any package *un*qualified elements of `:test-names` will be searched for in the `:test-package`.
-
-Note that FiveAM offers named test *suites*.  Typically it will be most convenient to make a small number of such suites for your system, and name only these suites in `test-names`, rather than naming each individual test.
-
-Doing `(asdf:test-system "foo/test")` will run all the tests in the `fiveam-tester` system.  However, as above, it is best to use ASDF's `:in-order-to` to connect `foo` to `foo/test` for testing purposes.  Then a user can simply do `(asdf:test-system "foo")` without needing to know how the tests are implemented.
-
-If any tests fail, a condition of type `asdf:fiveam-asdf-failure` will be raised. It is necessary to do this, because `asdf:test-system` does not return a value.  One can easily write a test script that will run `asdf:test-system` and either exit with 0 if the tests all pass, or 1 otherwise.
+If any tests fail, a condition of type `asdf:fiveam-asdf-failure` will be raised. It is
+necessary to do this, because `asdf:test-system` does not return a value.  One can easily
+write a test script that will run `asdf:test-system` and either exit with 0 if the tests
+all pass, or 1 otherwise.
 
 ### Test counts ###
 
-In our experience, it was possible to introduce bugs that would cause tests not to be run at all, which could appear indistinguishable from all the tests passing, since all the tests *that were run* would pass.
+In our experience, it was possible to introduce bugs that would cause tests not to be run
+at all, which could appear indistinguishable from all the tests passing, since all the
+tests *that were run* would pass.
 
-So we added the `:num-checks` option to `fiveam-tester` systems.  If you specify a number of checks (note that in FiveAM the number of checks is *not*, in general, the same as the number of *tests*), then a condition of type `fiveam-wrong-number-of-checks` will be raised if a differernt number of checks are actually run.
+So we added the `:num-checks` option to `fiveam-tester` systems.  If you specify a number
+of checks (note that in FiveAM the number of checks is *not*, in general, the same as the
+number of *tests*), then a condition of type `fiveam-wrong-number-of-checks` will be
+raised if a differernt number of checks are actually run.
 
-Bugs, misfeatures, etc.
--------------------
+### Using PACKAGE-INFERRED-SYSTEM to avoid writing out your dependency graph ###
 
-This extension mistakenly lives directly in the `ASDF` Common Lisp package. It should not, but I have not had the time to fix it.
+Define a system `"foo/test"` like above. Set its `:class` as
+`package-inferred-fiveam-tester-system`. Specify its `:test-names`, `:test-package` and
+`:num-checks` as appropriate. Do not specify a `:components` property. Set its
+`:depends-on` property to the list `("foo/test/package")`.
+
+Create a file `test/package.lisp` whose first form is a `uiop:define-package` form which
+defines the package `foo/test/package`. `:use`, `:mix`, `:mix-reexport`, `:import-from` or
+otherwise depend on any packages your tests need, likely including `fiveam`, `foo` and any
+other `foo/test/bar` files in your test suite. Each of those files must start with a
+similar `uiop:define-package` form.

--- a/code.lisp
+++ b/code.lisp
@@ -25,6 +25,7 @@ uninterned symbol.")
    (test-package
     :initarg :default-test-package
     :initarg :test-package
+    :reader test-package
     :documentation "A package designator for the TEST-NAMES which don't have explicit packages listed.
 
 If all the tests are in one package, you can just have a list of symbol designators (strings or keywords) in \
@@ -74,12 +75,6 @@ they are counted.")))
                       (actual-num-checks x))))
   (:documentation "Thrown when a FiveAM test suite has no failed tests, but the number of checks run does \
 not match the expected number."))
-
-(defgeneric test-package (x)
-  (:method ((x fiveam-tester-system))
-    (if (slot-boundp x 'test-package)
-        (slot-value x 'test-package)
-        (error "If package is not specified with each test-name, system's TEST-PACKAGE slot must be set."))))
 
 (defun test-designator-name (test-designator)
   (etypecase test-designator

--- a/code.lisp
+++ b/code.lisp
@@ -24,23 +24,19 @@ here.")
     :documentation "How many tests do you expect to run when
 you invoke the test-op on this system. For backwards compatibility,
 this slot is ignored if it's NIL. If bound, then when running the
-test-op, we will fail if the expected number of checks are not run.")
-   ))
+test-op, we will fail if the expected number of checks are not run.")))
 
 (define-condition fiveam-asdf-failure (error)
   ((failed-asdf-component
     :initarg :failed-asdf-component
-    :reader failed-asdf-component
-    ))
+    :reader failed-asdf-component))
   (:documentation "Superclass of error conditions that indicate that
   an ASDF test-op has failed."))
-
 
 (define-condition fiveam-test-fail (fiveam-asdf-failure)
   ((failed
     :initarg :failed
-    :reader failed
-    ))
+    :reader failed))
   (:report (lambda (x s)
               (format s "Tests on system ~a failed: ~{~t~a~%~}"
                       (component-name (failed-asdf-component x))
@@ -50,13 +46,11 @@ test-op, we will fail if the expected number of checks are not run.")
   ((expected-num-checks
     :initarg :expected
     :initarg :expected-num-checks
-    :reader expected-num-checks
-    )
+    :reader expected-num-checks)
    (actual-num-checks
     :initarg :actual-num-checks
     :initarg :actual
-    :reader actual-num-checks
-    ))
+    :reader actual-num-checks))
   (:report (lambda (x s)
               (format s "Unexpected number of tests on system ~a: Expected ~d got ~d."
                       (component-name (failed-asdf-component x))
@@ -118,7 +112,3 @@ test-op, we will fail if the expected number of checks are not run.")
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'fiveam-tester-system :asdf))
-
-
-
-

--- a/code.lisp
+++ b/code.lisp
@@ -7,27 +7,31 @@
   ((test-names
     :initarg :test-names
     :reader test-names
-    :documentation "A list whose elments are either
-cons cells of symbol and package designators or
-simply a symbol designator.
-  In the latter case, the symbols will be interned
-in the package designated by the TEST-PACKAGE slot,
-which must be bound.")
+    :documentation "A list of test designators, each of which is either a symbol designator \
+or a cons of (SYMBOL-NAME . PACKAGE-DESIGNATOR).
+
+Bare symbols will be interned in the package designated by the TEST-PACKAGE slot, which must be bound if \
+any are to be interned this way.
+
+The symbol designators, SYMBOL-NAMEs, and PACKAGE-DESIGNATORs may each be any of: a keyword, a string or an \
+uninterned symbol.")
    (test-package
     :initarg :default-test-package
     :initarg :test-package
-    :documentation "If all the tests are in one package, you can just
-have a list of test names in test-names, and get the package name from
-here.")
+    :documentation "A package designator for the TEST-NAMES which don't have explicit packages listed.
+
+If all the tests are in one package, you can just have a list of symbol designators (strings or keywords) in \
+test-names, and get the package name from here.")
    (num-checks
     :initarg :num-checks
     :reader num-checks
     :type (or null (integer 0))
     :initform nil
-    :documentation "How many tests do you expect to run when
-you invoke the test-op on this system. For backwards compatibility,
-this slot is ignored if it's NIL. If bound, then when running the
-test-op, we will fail if the expected number of checks are not run.")))
+    :documentation "Expected number of tests to be run when you invoke test-op on this system.
+
+If supplied and non-NIL, then when running the test-op, we will fail if the actual number of checks run does \
+not match the expected number expected number. See the FiveAM manual for the definition of a check and how \
+they are counted.")))
 
 (defclass package-inferred-fiveam-tester-system (package-inferred-system fiveam-tester-system)
   ())
@@ -36,32 +40,33 @@ test-op, we will fail if the expected number of checks are not run.")))
   ((failed-asdf-component
     :initarg :failed-asdf-component
     :reader failed-asdf-component))
-  (:documentation "Superclass of error conditions that indicate that
-  an ASDF test-op has failed."))
+  (:documentation "Superclass of error conditions that indicate that an ASDF test-op has failed."))
 
 (define-condition fiveam-test-fail (fiveam-asdf-failure)
   ((failed
     :initarg :failed
-    :reader failed))
+    :reader failed
+    :documentation "A list of failed tests"))
   (:report (lambda (x s)
               (format s "Tests on system ~a failed: ~{~t~a~%~}"
                       (component-name (failed-asdf-component x))
-                      (failed x)))))
+                      (failed x))))
+  (:documentation "Thrown when a FiveAM test fails when testing a `fiveam-tester-system'"))
 
 (define-condition fiveam-wrong-number-of-checks (fiveam-asdf-failure)
   ((expected-num-checks
-    :initarg :expected
     :initarg :expected-num-checks
     :reader expected-num-checks)
    (actual-num-checks
     :initarg :actual-num-checks
-    :initarg :actual
     :reader actual-num-checks))
   (:report (lambda (x s)
               (format s "Unexpected number of tests on system ~a: Expected ~d got ~d."
                       (component-name (failed-asdf-component x))
                       (expected-num-checks x)
-                      (actual-num-checks x)))))
+                      (actual-num-checks x))))
+  (:documentation "Thrown when a FiveAM test suite has no failed tests, but the number of checks run does \
+not match the expected number."))
 
 (defgeneric test-package (x)
   (:method ((x fiveam-tester-system))

--- a/code.lisp
+++ b/code.lisp
@@ -1,6 +1,13 @@
 (uiop:define-package #:fiveam-asdf
   (:use #:uiop #:asdf #:cl)
-  (:export #:fiveam-tester-system #:package-inferred-fiveam-tester-system))
+  (:export
+   ;; system subclasses
+   #:fiveam-tester-system #:package-inferred-fiveam-tester-system
+
+   ;; test failure conditions
+   #:fiveam-asdf-test-failure #:failed-asdf-component
+   #:fiveam-test-fail #:failed
+   #:fiveam-wrong-number-of-checks #:actual-num-checks #:expected-num-checks))
 (in-package #:fiveam-asdf)
 
 (defclass fiveam-tester-system (system)

--- a/code.lisp
+++ b/code.lisp
@@ -26,6 +26,9 @@ you invoke the test-op on this system. For backwards compatibility,
 this slot is ignored if it's NIL. If bound, then when running the
 test-op, we will fail if the expected number of checks are not run.")))
 
+(defclass package-inferred-fiveam-tester-system (package-inferred-system fiveam-tester-system)
+  ())
+
 (define-condition fiveam-asdf-failure (error)
   ((failed-asdf-component
     :initarg :failed-asdf-component
@@ -111,4 +114,5 @@ test-op, we will fail if the expected number of checks are not run.")))
   (cons '(load-op "fiveam") (call-next-method)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'fiveam-tester-system :asdf))
+  (export 'fiveam-tester-system :asdf)
+  (export 'package-inferred-fiveam-tester-system :asdf))

--- a/code.lisp
+++ b/code.lisp
@@ -1,4 +1,7 @@
-(in-package :asdf)
+(uiop:define-package #:fiveam-asdf
+  (:use #:uiop #:asdf #:cl)
+  (:export #:fiveam-tester-system #:package-inferred-fiveam-tester-system))
+(in-package #:fiveam-asdf)
 
 (defclass fiveam-tester-system (system)
   ((test-names
@@ -130,5 +133,7 @@ test-op, we will fail if the expected number of checks are not run.")))
   (cons '(load-op "fiveam") (call-next-method)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'fiveam-tester-system :asdf)
-  (export 'package-inferred-fiveam-tester-system :asdf))
+  (import '(fiveam-tester-system package-inferred-fiveam-tester-system)
+          '#:asdf)
+  (export '(fiveam-tester-system package-inferred-fiveam-tester-system)
+          '#:asdf))

--- a/code.lisp
+++ b/code.lisp
@@ -2,7 +2,8 @@
   (:use #:uiop #:asdf #:cl)
   (:export
    ;; system subclasses
-   #:fiveam-tester-system #:package-inferred-fiveam-tester-system
+   #:fiveam-tester-system #:test-names  #:test-package #:num-checks
+   #:package-inferred-fiveam-tester-system
 
    ;; test failure conditions
    #:fiveam-asdf-test-failure #:failed-asdf-component
@@ -11,7 +12,7 @@
 (in-package #:fiveam-asdf)
 
 (defclass fiveam-tester-system (system)
-  ((test-names
+  ((%test-names
     :initarg :test-names
     :reader test-names
     :documentation "A list of test designators, each of which is either a symbol designator \
@@ -22,7 +23,7 @@ any are to be interned this way.
 
 The symbol designators, SYMBOL-NAMEs, and PACKAGE-DESIGNATORs may each be any of: a keyword, a string or an \
 uninterned symbol.")
-   (test-package
+   (%test-package
     :initarg :default-test-package
     :initarg :test-package
     :reader test-package
@@ -30,7 +31,7 @@ uninterned symbol.")
 
 If all the tests are in one package, you can just have a list of symbol designators (strings or keywords) in \
 test-names, and get the package name from here.")
-   (num-checks
+   (%num-checks
     :initarg :num-checks
     :reader num-checks
     :type (or null (integer 0))
@@ -45,13 +46,13 @@ they are counted.")))
   ())
 
 (define-condition fiveam-asdf-failure (error)
-  ((failed-asdf-component
+  ((%failed-asdf-component
     :initarg :failed-asdf-component
     :reader failed-asdf-component))
   (:documentation "Superclass of error conditions that indicate that an ASDF test-op has failed."))
 
 (define-condition fiveam-test-fail (fiveam-asdf-failure)
-  ((failed
+  ((%failed
     :initarg :failed
     :reader failed
     :documentation "A list of failed tests"))
@@ -62,10 +63,10 @@ they are counted.")))
   (:documentation "Thrown when a FiveAM test fails when testing a `fiveam-tester-system'"))
 
 (define-condition fiveam-wrong-number-of-checks (fiveam-asdf-failure)
-  ((expected-num-checks
+  ((%expected-num-checks
     :initarg :expected-num-checks
     :reader expected-num-checks)
-   (actual-num-checks
+   (%actual-num-checks
     :initarg :actual-num-checks
     :reader actual-num-checks))
   (:report (lambda (x s)

--- a/fiveam-asdf.asd
+++ b/fiveam-asdf.asd
@@ -18,12 +18,12 @@
 
 (defsystem "fiveam-asdf"
   :long-description
-  "System that defines two new system classes, FIVEAM-TESTER-SYSTEM and PACKAGE-INFERRED-FIVEAM-TESTER-SYSTEM, \
+  "Defines two new system classes, FIVEAM-TESTER-SYSTEM and PACKAGE-INFERRED-FIVEAM-TESTER-SYSTEM, \
 that provide functionality for running tests using FIVEAM and raising an error if the tests fail \(useful for \
 incorporation in a Jenkins or Hudson build\)."
-  :description "Library to integrate FiveAM testing with ASDF TEST-OP and TEST-SYSTEM"
+  :description "Integrate FiveAM testing with ASDF TEST-OP and TEST-SYSTEM"
   :depends-on (:asdf)
   :components ((:file "code"))
-  :author "Robert P. Goldman and John Maraist"
+  :author "Phoebe Goldman, Robert P. Goldman and John Maraist"
   :version "3.0"
   :license "Lisp LGPL")

--- a/fiveam-asdf.asd
+++ b/fiveam-asdf.asd
@@ -16,13 +16,7 @@
 ;;;
 ;;;---------------------------------------------------------------------------
 
-(defpackage :fiveam-asdf-asd
-  (:use :common-lisp :asdf)
-  )
-
-(in-package :fiveam-asdf-asd)
-
-(defsystem fiveam-asdf
+(defsystem "fiveam-asdf"
   :long-description
   "System that defines a new system class FIVEAM-TESTER
 that provides functionality for running tests using
@@ -33,6 +27,5 @@ build\)."
   :depends-on (:asdf)
   :components ((:file "code"))
   :author "Robert P. Goldman and John Maraist"
-  :version "2.0"
-  :license "Lisp LGPL"
-  )
+  :version "3.0"
+  :license "Lisp LGPL")

--- a/fiveam-asdf.asd
+++ b/fiveam-asdf.asd
@@ -18,11 +18,9 @@
 
 (defsystem "fiveam-asdf"
   :long-description
-  "System that defines a new system class FIVEAM-TESTER
-that provides functionality for running tests using
-FIVEAM and raising an error if the tests fail
-\(useful for incorporation in a Jenkins or Hudson
-build\)."
+  "System that defines two new system classes, FIVEAM-TESTER-SYSTEM and PACKAGE-INFERRED-FIVEAM-TESTER-SYSTEM, \
+that provide functionality for running tests using FIVEAM and raising an error if the tests fail \(useful for \
+incorporation in a Jenkins or Hudson build\)."
   :description "Library to integrate FiveAM testing with ASDF TEST-OP and TEST-SYSTEM"
   :depends-on (:asdf)
   :components ((:file "code"))


### PR DESCRIPTION
This PR does several things (which honestly could've probably been their own separate PRs if I cared even a little):

- Defines `package-inferred-fiveam-tester-system`, which subclasses both `package-inferred-system` and `fiveam-tester-system`.
- Moves private symbols into their own package to avoid clogging the `asdf` package.
- Exports from the `fiveam-asdf` package some symbols which I believe to be useful, such as the condition-classes thrown on test failures and their slot-readers.
- Updates the README, various documentation strings, and the ASD's `:description` and `:long-description`s.
- Refactors the `perform` `test-op` method to use many small human-readable functions rather than a single huge `loop` form.
- Bumps `:version` to `"3.0"`, since re-homing various symbols which aren't reexported from `asdf` may be a breaking change if naughty users have been accessing non-exported symbols.
- Removes a method on `test-symbols` which I believe to have been totally useless, since it was designed to handle the `slot-unbound` case of a slot which had an `initform`.
- Adds myself to the `:authors`, since I think by lines-of-code I've now written a majority of this library.
- Expands the definition of a test designator to allow strings in addition to various symbol-ey objects. (I think? It's not entirely clear to me whether `:test-names ("MY-TEST-NAME") :test-package "MY-TEST-PACKAGE"` was valid before. It is now.)
