### PR TITLE
Fix a very stupid and very breaking bug

### DIFF
--- a/code.lisp
+++ b/code.lisp
@@ -103,7 +103,7 @@ not match the expected number."))
         appending (funcall runner test)))
 
 (defun explain-results (results)
-  (funcall (intern (symbol-name '#:run) '#:fiveam)
+  (funcall (intern (symbol-name '#:explain!) '#:fiveam)
            results))
 
 (defun verify-num-checks (results tester-system)

--- a/fiveam-asdf.asd
+++ b/fiveam-asdf.asd
@@ -30,5 +30,5 @@ incorporation in a CI system such as Jenkins, GitHub actions, etc.\)."
   :depends-on (:asdf)
   :components ((:file "code"))
   :author "Phoebe Goldman, Robert P. Goldman and John Maraist"
-  :version "3.0"
+  :version "3.0.1"
   :license "Lisp LGPL")


### PR DESCRIPTION
`explain-results` was meant to call `explain!` (duh), but I somehow
managed to instead have it call `run!`. Oops...